### PR TITLE
Order log entries when verifying migration status

### DIFF
--- a/beam-migrate/Database/Beam/Migrate/Simple.hs
+++ b/beam-migrate/Database/Beam/Migrate/Simple.hs
@@ -119,7 +119,7 @@ bringUpToDateWithHooks :: forall db be m
 bringUpToDateWithHooks hooks be@(BeamMigrationBackend { backendRenderSyntax = renderSyntax' }) steps = do
   ensureBackendTables be
 
-  entries <- runSelectReturningList $ select $
+  entries <- runSelectReturningList $ select $ orderBy_ (asc_ . _logEntryId) $
              all_ (_beamMigrateLogEntries (beamMigrateDb @be @m))
   let verifyMigration :: Int -> T.Text -> Migration be a -> StateT [LogEntry] (WriterT (Max Int) m) a
       verifyMigration stepIx stepNm step =


### PR DESCRIPTION
Migrations originally created by **beam** 0.7.3 were not working after a migration created by 0.8.0 due to the lack of an ORDER BY clause against the `beam_version` table.